### PR TITLE
Fix: Standardize port configurations and API URLs

### DIFF
--- a/dev-server.mjs
+++ b/dev-server.mjs
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 console.log('Starting development servers...');
 
 // Start Hono backend (already managed by workflow)
-console.log('✓ Hono backend running on port 5000');
+console.log('✓ Hono backend expected on port 4000 (run separately with npm run dev)');
 
 // Start Python AI service
 console.log('Starting Python AI service...');
@@ -22,7 +22,7 @@ const aiProcess = spawn('python3', ['simple_main.py'], {
 console.log('Starting Next.js frontend...');
 const frontendProcess = spawn('npx', ['next', 'dev', '--port', '3000', '--hostname', '0.0.0.0'], {
   cwd: __dirname,
-  env: { ...process.env, NEXT_PUBLIC_API_URL: 'http://localhost:5000' },
+  env: { ...process.env, NEXT_PUBLIC_API_URL: 'http://localhost:4000' },
   stdio: ['ignore', 'pipe', 'pipe']
 });
 

--- a/next.config.js
+++ b/next.config.js
@@ -2,16 +2,17 @@
 const nextConfig = {
   env: {
     NEXT_PUBLIC_API_URL: process.env.NODE_ENV === 'production' 
-      ? process.env.NEXT_PUBLIC_API_URL || 'https://your-domain.replit.app'
-      : 'http://localhost:5000',
+      ? process.env.NEXT_PUBLIC_API_URL || 'https://your-domain.replit.app' // This can remain as a fallback for public URL
+      : 'http://localhost:4000', // Changed for dev
   },
   async rewrites() {
     return [
       {
         source: '/api/:path*',
+        // For production, use NEXT_PUBLIC_API_URL. For dev, use localhost:4000.
         destination: process.env.NODE_ENV === 'production' 
-          ? `${process.env.API_URL || 'http://localhost:5000'}/api/:path*`
-          : 'http://localhost:5000/api/:path*',
+          ? `${process.env.NEXT_PUBLIC_API_URL || 'https://your-domain.replit.app'}/api/:path*` // Use the public API URL for prod
+          : 'http://localhost:4000/api/:path*', // Changed for dev
       },
     ];
   },

--- a/run-frontend.mjs
+++ b/run-frontend.mjs
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 
 const env = {
   ...process.env,
-  NEXT_PUBLIC_API_URL: 'http://localhost:5000',
+  NEXT_PUBLIC_API_URL: 'http://localhost:4000',
   PORT: '3000',
   HOSTNAME: '0.0.0.0'
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -26,7 +26,7 @@ async function startServer() {
   // Register API routes
   registerRoutes(app);
 
-  const port = parseInt(process.env.PORT || '5000');
+  const port = parseInt(process.env.PORT || '4000');
   
   log(`Backend server starting on port ${port}`);
   log(`Environment: ${process.env.NODE_ENV || 'development'}`);

--- a/start-all-services.js
+++ b/start-all-services.js
@@ -12,7 +12,7 @@ console.log('Starting all services for the tech stack recommendation app...');
 // Environment variables
 const env = {
   ...process.env,
-  NEXT_PUBLIC_API_URL: 'http://localhost:5000',
+  NEXT_PUBLIC_API_URL: 'http://localhost:4000',
   NODE_ENV: 'development',
   MISTRAL_API_KEY: process.env.MISTRAL_API_KEY
 };
@@ -80,7 +80,7 @@ process.on('SIGTERM', shutdown);
 
 // Keep process alive
 console.log('All services starting...');
-console.log('Backend (Hono): http://localhost:5000');
+console.log('Backend (Hono): http://localhost:4000 (run separately with npm run dev)');
 console.log('Frontend (Next.js): http://localhost:3000');
 console.log('AI Service: http://localhost:8000');
 console.log('Press Ctrl+C to stop all services');


### PR DESCRIPTION
This commit resolves inconsistencies in port usage and API URL configurations across local development and Docker environments.

Key changes:

1.  **Node.js Backend Port:**
    *   Changed the default port for the Node.js backend (`server/index.ts`) from 5000 to 4000 to align with the Docker setup (`Dockerfile.server` and `docker-compose.yml`).
    *   The `package.json` `dev` script now correctly picks up this new default.

2.  **Next.js Configuration (`next.config.js`):**
    *   Updated `NEXT_PUBLIC_API_URL` for development to `http://localhost:4000`.
    *   Adjusted the `rewrites` destination for development to proxy `/api/*` to `http://localhost:4000/api/*`.
    *   Made production rewrite destination more robust by consistently using `process.env.NEXT_PUBLIC_API_URL`.

3.  **Development Helper Scripts:**
    *   Modified `dev-server.mjs`, `run-frontend.mjs`, and `start-all-services.js` to:
        *   Set `NEXT_PUBLIC_API_URL` to `http://localhost:4000` for the Next.js process.
        *   Update console log messages to reflect the Node.js backend's new port (4000).

4.  **Verification of Python API Ports:**
    *   Confirmed local Python API (via `simple_main.py` used by dev scripts) runs on port 8000, and the Node.js backend correctly defaults to this for local development.
    *   Confirmed Dockerized Python API (`main.py` via `Dockerfile.python`) runs on container port 5000 (mapped to host port 5000), and the Dockerized Node.js backend correctly targets it at `http://python-api:5000`.

These changes ensure that the Next.js frontend (running on port 3000) can consistently connect to the Node.js backend, whether services are run locally or via Docker. The issue regarding `Dockerfile.client` (being a Vite setup instead of Next.js) is noted but considered a separate item from this primary port and connectivity fix.